### PR TITLE
update README.md: `ActiveHash::Matcher::Like`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ class Country < ActiveHash::Base; end
 Country.like(name: 'Cana%')
 ```
 
-If you want to use `like` in the where method parameter, you can use `ActiveHash::Match::Like` matcher.
+If you want to use `like` in the where method parameter, you can use `ActiveHash::Matcher::Like` matcher.
 
 ```rb
 # Specify match type.
-Country.where(name: ActiveHash::Match::Like.new('Cana%'))
+Country.where(name: ActiveHash::Matcher::Like.new('Cana%'))
 
 # Or use forward, backward, partial method.
-Country.where(name: ActiveHash::Match::Like.forward('Cana'))
+Country.where(name: ActiveHash::Matcher::Like.forward('Cana'))
 ```
 
 ## Custom matcher
 
-`ActiveHash::Match::Like` is one of custom matcher. You can create your custom matcher.
+`ActiveHash::Matcher::Like` is one of custom matcher. You can create your custom matcher.
 It should have `call` method like the following:
 
 ```rb


### PR DESCRIPTION
The tests in [`like_test.rb`](https://github.com/monochromegane/active_hash-like/blob/master/test/active_hash/matcher/like_test.rb) said the like matcher is `ActiveHash::Matcher::Like` but `README.md` said it was `ActiveHash::Match::Like`.

Just updated the text in `README.md`.
